### PR TITLE
Pebbleアプリから返す日付データのフォーマット変更

### DIFF
--- a/dConnectDevicePebbleApp/src/menu_item.c
+++ b/dConnectDevicePebbleApp/src/menu_item.c
@@ -20,7 +20,7 @@
  */
 
 #define FIRST_MENU_TITLE  "start App"
-#define FIRST_MENU_TEXT   "ver 2017/03/01 16:30"
+#define FIRST_MENU_TEXT   "ver 2017/12/04"
 #define MENU_ITEM_MAX 20
 
 static int16_t how_many_item = 0;

--- a/dConnectDevicePebbleApp/src/send_message.c
+++ b/dConnectDevicePebbleApp/src/send_message.c
@@ -37,14 +37,8 @@ void send_message()
             char str[64];
             // ポインタにしないとTupletCStringがエラーを出す
             char *p = str;
-            int year = local->tm_year + 1900;
-            int month = local->tm_mon + 1;
-            int day = local->tm_mday;
-            int hour = local->tm_hour;
-            int min = local->tm_min;
-            int sec = local->tm_sec;
-            // RFC 3339に合わせて変換を行う
-            snprintf(str, sizeof(str), "%4d-%02d-%02dT%02d:%02d:%02d", year, month, day, hour, min, sec);
+            // RFC 3339に合わせて変換を行えないため、ISO8601の形式でデバイス側に渡す。デバイス側で変換する。
+            strftime(str, sizeof(str), "%FT%T%z", local);
             entry_log("get setting/date", str);
             Tuplet dateTuple = TupletCString(KEY_PARAM_SETTING_DATE, p);
             dict_write_tuplet(iter, &dateTuple);


### PR DESCRIPTION
## 更新内容
* PebbleAPP側ではISO8601で返し、スマートフォン側でRFC3339に変換するようにする。